### PR TITLE
Fixes tier2/tier3 not linking properly on loonix

### DIFF
--- a/premake/sourcesdk.lua
+++ b/premake/sourcesdk.lua
@@ -195,10 +195,15 @@ function IncludeSDKTier2(directory)
 
 	directory = GetSDKPath(directory)
 
+	filter("system:windows or macosx")
+		links("tier2")
+
+	filter("system:linux")
+		linkoptions(path.getabsolute(directory) .. "/lib/public/linux32/tier2.a")
+
 	filter({})
 
 	includedirs(directory .. "/public/tier2")
-	links("tier2")
 end
 
 function IncludeSDKTier3(directory)
@@ -206,10 +211,15 @@ function IncludeSDKTier3(directory)
 
 	directory = GetSDKPath(directory)
 
+	filter("system:windows or macosx")
+		links("tier3")
+
+	filter("system:linux")
+		linkoptions(path.getabsolute(directory) .. "/lib/public/linux32/tier3.a")
+
 	filter({})
 
 	includedirs(directory .. "/public/tier3")
-	links("tier3")
 end
 
 function IncludeSDKMathlib(directory)

--- a/premake/sourcesdk.lua
+++ b/premake/sourcesdk.lua
@@ -195,6 +195,8 @@ function IncludeSDKTier2(directory)
 
 	directory = GetSDKPath(directory)
 
+	includedirs(directory .. "/public/tier2")
+
 	filter("system:windows or macosx")
 		links("tier2")
 
@@ -202,14 +204,14 @@ function IncludeSDKTier2(directory)
 		linkoptions(path.getabsolute(directory) .. "/lib/public/linux32/tier2.a")
 
 	filter({})
-
-	includedirs(directory .. "/public/tier2")
 end
 
 function IncludeSDKTier3(directory)
 	IncludePackage("sdktier3")
 
 	directory = GetSDKPath(directory)
+
+	includedirs(directory .. "/public/tier3")
 
 	filter("system:windows or macosx")
 		links("tier3")
@@ -218,8 +220,6 @@ function IncludeSDKTier3(directory)
 		linkoptions(path.getabsolute(directory) .. "/lib/public/linux32/tier3.a")
 
 	filter({})
-
-	includedirs(directory .. "/public/tier3")
 end
 
 function IncludeSDKMathlib(directory)


### PR DESCRIPTION
```
@swadical substitute links("tierX") with
filter("system:windows or macosx")
    links("tierX")

filter("system:linux")
    linkoptions(path.getabsolute(directory) .. "/lib/public/linux32/tierX.a")

for tier2 and tier3
```

- @metaman