### PR TITLE
Add RAD_TELEMETRY_DISABLED to fix compilation errors

### DIFF
--- a/premake/sourcesdk.lua
+++ b/premake/sourcesdk.lua
@@ -22,7 +22,7 @@ local function IncludeSDKCommonInternal(directory)
 	defines(_project.serverside and "GAME_DLL" or "CLIENT_DLL")
 
 	filter("system:windows")
-		defines("WIN32")
+		defines({"WIN32", "RAD_TELEMETRY_DISABLED"})
 		disablewarnings("4324")
 		libdirs(path.join(directory, "lib", "public"))
 


### PR DESCRIPTION
When trying to compile the mathlib, it's missing fieldtype_t and string_t for things such as variant_t.h 

I haven't seen any compilation failures for the other inclusions regarding these, so I shoved this into the premake file.

Also, when compiling on windows, telemetry needs to be disabled for it to compile. A file being included by the vprof_telemetry.h is missing: "../../thirdparty/telemetry/include/telemetry.h"
