### PR TITLE
Add project generator version 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /projects/
 config.v1.lua
 config.v2.lua
+config.v3.lua

--- a/build/.appveyor.yml.template
+++ b/build/.appveyor.yml.template
@@ -20,7 +20,6 @@ environment:
   TARGET_ARCHITECTURE_64: x86_64
   PROJECT_GENERATOR_VERSION: 2
   COMPILER_PLATFORM: vs2019
-  DISABLE_X86_64_BUILD: true
 install:
 - ps: 'Invoke-Expression ((New-Object System.Net.WebClient).DownloadString("$env:BOOTSTRAP_URL"))'
 cache:

--- a/build/.travis.yml.template
+++ b/build/.travis.yml.template
@@ -18,7 +18,6 @@ env:
       TARGET_ARCHITECTURE_64=x86_64
       PROJECT_GENERATOR_VERSION=2
       COMPILER_PLATFORM=gmake
-      DISABLE_X86_64_BUILD=true
 matrix:
   include:
     - os: linux

--- a/build/azure-pipelines.yml.template
+++ b/build/azure-pipelines.yml.template
@@ -6,7 +6,6 @@ variables:
   GARRYSMOD_COMMON_REPOSITORY: https://github.com/danielga/garrysmod_common.git
   PROJECT_GENERATOR_VERSION: 2
   REPOSITORY_DIR: $(System.DefaultWorkingDirectory)
-  DISABLE_X86_64_BUILD: true
 trigger:
   tags:
     include:

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -19,7 +19,7 @@ Write-Output "Building module..."
 Invoke-Call { & "$MSBuild" "$MODULE_NAME.sln" /p:Configuration=Release /p:Platform=Win32 /m } -ErrorAction Stop
 Pop-Location
 
-if ($PROJECT_GENERATOR_VERSION -eq 2 -and -not $DISABLE_X86_64_BUILD) {
+if ($PROJECT_GENERATOR_VERSION -ge 3) {
 	Push-Location "$REPOSITORY_DIR/projects/$PROJECT_OS/$COMPILER_PLATFORM" -ErrorAction Stop
 	Write-Output "Building module..."
 	Invoke-Call { & "$MSBuild" "$MODULE_NAME.sln" /p:Configuration=Release /p:Platform=x64 /m } -ErrorAction Stop

--- a/build/build.sh
+++ b/build/build.sh
@@ -18,14 +18,14 @@ echo "Running premake5..."
 "$PREMAKE5" "$COMPILER_PLATFORM"
 popd
 
-if [ ! "$(uname -s)" = "Darwin" ]; then
+if [ "$PROJECT_GENERATOR_VERSION" -le "2" ] || [ ! "$(uname -s)" = "Darwin" ]; then
 	pushd "$REPOSITORY_DIR/projects/$PROJECT_OS/$COMPILER_PLATFORM"
 	echo "Building module with ${JOBS} job(s)..."
 	make -j "$JOBS" config=release_x86
 	popd
 fi
 
-if [ "$PROJECT_GENERATOR_VERSION" = "2" ] && [ -z "${DISABLE_X86_64_BUILD+x}" ]; then
+if [ "$PROJECT_GENERATOR_VERSION" -ge "3" ]; then
 	pushd "$REPOSITORY_DIR/projects/$PROJECT_OS/$COMPILER_PLATFORM"
 	echo "Building module with ${JOBS} job(s)..."
 	make -j "$JOBS" config=release_x86_64

--- a/build/setup.ps1
+++ b/build/setup.ps1
@@ -15,8 +15,4 @@ ValidateVariableOrSetDefault "PREMAKE5" -Default "$DEPENDENCIES/windows/premake-
 ValidateVariableOrSetDefault "PROJECT_OS" -Default "windows"
 ValidateVariableOrSetDefault "PROJECT_GENERATOR_VERSION" -Default "1"
 
-if (Test-Path env:DISABLE_X86_64_BUILD) {
-	Set-Variable DISABLE_X86_64_BUILD -Value (Get-Item env:DISABLE_X86_64_BUILD).Value -Scope Global -ErrorAction Stop -Confirm:$false
-}
-
 CreateDirectoryForcefully $DEPENDENCIES

--- a/build/setup.sh
+++ b/build/setup.sh
@@ -15,7 +15,6 @@ validate_variable_or_set_default "GARRYSMOD_COMMON_BRANCH" "master"
 validate_variable_or_set_default "GARRYSMOD_COMMON" "$DEPENDENCIES/garrysmod_common"
 validate_variable_or_set_default "COMPILER_PLATFORM" "gmake"
 validate_variable_or_set_default "PROJECT_GENERATOR_VERSION" "1"
-validate_variable_or_set_default "DISABLE_X86_64_BUILD" "true"
 
 case "$(uname -s)" in
     Linux*)

--- a/config.v3.lua.template
+++ b/config.v3.lua.template
@@ -1,0 +1,12 @@
+-- Copy this file to config.v2.lua to override the defaults on premake/config.v2.default.lua
+
+-- These paths are relative to the premake5.lua file (or whatever you named it) of your project
+-- They can be absolute paths too if you so desire
+-- Path for the workspace files
+WORKSPACE_DIRECTORY = "projects/" .. os.target() .. "/" .. _ACTION
+
+-- Path for the source files (beware this will be used by all projects)
+SOURCE_DIRECTORY = "source"
+
+-- Path for the garrysmod/lua/bin directory (where the compiled files will be copied to)
+GARRYSMOD_LUA_BIN_DIRECTORY = nil

--- a/generator.v2.lua
+++ b/generator.v2.lua
@@ -1,5 +1,17 @@
 -- Version 2 of the project generator
 
+assert(_ACTION ~= nil, "no action (vs20**, gmake or xcode for example) provided!")
+
+include("premake/version.lua")
+
+local default_project_generator_version = 2
+
+local requested_version
+PROJECT_GENERATOR_VERSION, requested_version = GetRequestedProjectGeneratorVersionOrDefault(default_project_generator_version)
+if requested_version and PROJECT_GENERATOR_VERSION ~= default_project_generator_version then
+    error(string.format("environment variable PROJECT_GENERATOR_VERSION (%d) doesn't match this generators version (%d)", PROJECT_GENERATOR_VERSION, default_project_generator_version))
+end
+
 include("premake/config.v2.default.lua")
 dofileopt("config.v2.lua")
 include("premake/generator.lua")

--- a/generator.v3.lua
+++ b/generator.v3.lua
@@ -1,10 +1,11 @@
--- Version 1 of the project generator
+-- Version 3 of the project generator
+-- Enables x86-64 compilation
 
 assert(_ACTION ~= nil, "no action (vs20**, gmake or xcode for example) provided!")
 
 include("premake/version.lua")
 
-local default_project_generator_version = 1
+local default_project_generator_version = 3
 
 local requested_version
 PROJECT_GENERATOR_VERSION, requested_version = GetRequestedProjectGeneratorVersionOrDefault(default_project_generator_version)
@@ -12,6 +13,6 @@ if requested_version and PROJECT_GENERATOR_VERSION ~= default_project_generator_
     error(string.format("environment variable PROJECT_GENERATOR_VERSION (%d) doesn't match this generators version (%d)", PROJECT_GENERATOR_VERSION, default_project_generator_version))
 end
 
-include("premake/config.v1.default.lua")
-dofileopt("config.v1.lua")
+include("premake/config.v3.default.lua")
+dofileopt("config.v3.lua")
 include("premake/generator.lua")

--- a/premake/config.v3.default.lua
+++ b/premake/config.v3.default.lua
@@ -1,0 +1,10 @@
+-- These default paths are relative to the premake5.lua file (or whatever you named it) of your project
+-- They can be absolute paths too if you so desire
+-- Default path for the workspace files
+WORKSPACE_DIRECTORY = "projects/" .. os.target() .. "/" .. _ACTION
+
+-- Default path for the source files (beware this will be used by all projects)
+SOURCE_DIRECTORY = "source"
+
+-- Default path for the garrysmod/lua/bin directory (where the compiled files will be copied to)
+GARRYSMOD_LUA_BIN_DIRECTORY = nil

--- a/premake/generator.lua
+++ b/premake/generator.lua
@@ -1,5 +1,3 @@
-assert(_ACTION ~= nil, "no action (vs20**, gmake or xcode for example) provided!")
-
 newoption({
 	trigger = "workspace",
 	description = "Sets the path for the workspace directory",
@@ -86,10 +84,15 @@ function CreateWorkspace(config)
 		strictaliasing("Level3")
 		vectorextensions("SSE2")
 		pic("On")
-		platforms({"x86_64", "x86"})
 		targetdir("%{wks.location}/%{cfg.architecture}/%{cfg.buildcfg}")
 		debugdir("%{wks.location}/%{cfg.architecture}/%{cfg.buildcfg}")
 		objdir("!%{wks.location}/%{cfg.architecture}/%{cfg.buildcfg}/intermediate/%{prj.name}")
+
+		if PROJECT_GENERATOR_VERSION < 3 then
+			platforms("x86")
+		else
+			platforms({"x86_64", "x86"})
+		end
 
 		if abi_compatible then
 			configurations({"ReleaseWithSymbols", "Release"})

--- a/premake/version.lua
+++ b/premake/version.lua
@@ -1,0 +1,26 @@
+function GetRequestedProjectGeneratorVersionOrDefault(default_project_generator_version)
+	if default_project_generator_version ~= nil then
+		local default_type = type(default_project_generator_version)
+		if default_type ~= "number" then
+			error(string.format("invalid default version for the project generator (type %s)", default_type))
+		end
+	end
+
+	local version = os.getenv("PROJECT_GENERATOR_VERSION") or PROJECT_GENERATOR_VERSION
+	local requested_version = true
+	if version == nil then
+		version = default_project_generator_version
+		requested_version = false
+	end
+
+	if requested_version then
+		local number_version = tonumber(version)
+		if number_version == nil then
+			error(string.format("requested an invalid version (%s) of the project generator", version))
+		end
+
+		version = number_version
+	end
+
+	return version, requested_version
+end

--- a/premake5.lua
+++ b/premake5.lua
@@ -1,3 +1,22 @@
--- Version 1 of the project generator
+-- Automatic generator version selector
 
-include("generator.v1.lua")
+assert(_ACTION ~= nil, "no action (vs20**, gmake or xcode for example) provided!")
+
+include("premake/version.lua")
+
+local default_project_generator_version = 1
+
+local version, requested_version = GetRequestedProjectGeneratorVersionOrDefault(default_project_generator_version)
+
+local path = string.format("%s/generator.v%d.lua", _SCRIPT_DIR, version)
+if os.isfile(path) then
+    if requested_version then
+        print(string.format("Selected version %d of the project generator", version))
+    else
+        print("No version of the project generator specified, defaulting to version " .. default_project_generator_version)
+    end
+
+    include(path)
+else
+    error(string.format("requested an unknown version (%s) of the project generator", version))
+end


### PR DESCRIPTION
Move x86-64 builds into generator version 3
Remove DISABLE_X86_64_BUILD env var
Add macOS x86 builds back for generator versions below 3
Change premake5.lua into an auto-version selector depending on the value of the PROJECT_GENERATOR_VERSION env var
Improve handling of the _ACTION value