### PR TITLE
Add pch_header and pch_source to CreateProject config

### DIFF
--- a/premake/generator.lua
+++ b/premake/generator.lua
@@ -75,7 +75,7 @@ function CreateWorkspace(config)
 		language("C++")
 		location(_workspace.directory)
 		warnings("Extra")
-		flags({"NoPCH", "MultiProcessorCompile", "ShadowedVariables", "UndefinedIdentifiers"})
+		flags({"MultiProcessorCompile", "ShadowedVariables", "UndefinedIdentifiers"})
 		defines({"GMOD_ALLOW_OLD_TYPES", "GMOD_ALLOW_LIGHTUSERDATA"})
 		characterset("MBCS")
 		intrinsics("On")
@@ -284,6 +284,16 @@ function CreateProject(config)
 		end
 	end
 
+	local pch_enabled = false
+	if config.pch_header ~= nil or config.pch_source ~= nil then
+		assert(config.pch_header ~= nil, "'phc_header' must be supplied when 'pch_source' is supplied!")
+		assert(config.pch_source ~= nil, "'pch_source' must be supplied when 'phc_header' is supplied!")
+		assert(type(config.pch_header) == "string", "'pch_header' is not a string!")		
+		assert(type(config.pch_source) == "string", "'pch_source' is not a string!")
+		assert(os.isfile(sourcepath .. "/" .. config.pch_source), "'pch_source' file " .. config.pch_source .. " could not be found!")
+		pch_enabled = true
+	end
+
 	local name = (is_server and "gmsv_" or "gmcl_") .. _workspace.name
 
 	if abi_compatible and os.istarget("windows") and _ACTION ~= "vs2015" and _ACTION ~= "vs2017" and _ACTION ~= "vs2019" then
@@ -307,6 +317,13 @@ function CreateProject(config)
 			configurations({"ReleaseWithSymbols", "Release"})
 		else
 			configurations({"ReleaseWithSymbols", "Release", "Debug"})
+		end
+
+		if pch_enabled then
+			pchheader(config.pch_header)
+			pchsource(sourcepath .. "/" .. config.pch_source)
+		else
+			flags("NoPCH")
 		end
 
 		kind("SharedLib")


### PR DESCRIPTION
Adds support for precompiled headers, default remains to flag NoPCH although under projects instead of workspaces.