### PR TITLE
Add ability to suppress 32 or 64 bit builds individually for CI purposes

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,1 @@
+external-sources=true

--- a/build/bootstrap.sh
+++ b/build/bootstrap.sh
@@ -39,21 +39,25 @@ function update_local_git_repository {
 		echo "Fetching all branches from remote in \"${DIRECTORY}\"..."
 		git fetch --quiet --all --prune
 
-		local CURBRANCH=$(git symbolic-ref --quiet --short HEAD)
-		if [ ! "$BRANCH" = "$CURBRANCH" ]; then
+		local CURBRANCH
+		CURBRANCH=$(git symbolic-ref --quiet --short HEAD)
+		if [ "$BRANCH" != "$CURBRANCH" ]; then
 			echo "Checking out branch \"${BRANCH}\" in \"${DIRECTORY}\"..."
 			git checkout --quiet --force "$BRANCH"
 			local UPDATED=1
 		fi
 
-		local LOCAL=$(git rev-parse @)
-		local REMOTE=$(git rev-parse @{u})
-		local BASE=$(git merge-base @ @{u})
+		local LOCAL
+		LOCAL=$(git rev-parse @)
+		local REMOTE
+		REMOTE=$(git rev-parse @\{u\})
+		local BASE
+		BASE=$(git merge-base @ @\{u\})
 
 		if [ "$LOCAL" = "$BASE" ]; then
 			echo "Branch \"${BRANCH}\" in \"${DIRECTORY}\" needs updating..."
 			local UPDATED=1
-		elif [ ! "$LOCAL" = "$REMOTE" ]; then
+		elif [ "$LOCAL" != "$REMOTE" ]; then
 			echo "Hard resetting branch \"${BRANCH}\" in \"${DIRECTORY}\"..."
 			git reset --quiet --hard "origin/${BRANCH}"
 			git clean --quiet --force -dx

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -14,14 +14,14 @@ Write-Output "Running premake5..."
 Invoke-Call { & "$PREMAKE5" "$COMPILER_PLATFORM" } -ErrorAction Stop
 Pop-Location
 
-if ($env:DISABLE_32BIT -ne "true") {
+if (ValueIsFalsy $DISABLE_32BIT) {
 	Push-Location "$REPOSITORY_DIR/projects/$PROJECT_OS/$COMPILER_PLATFORM" -ErrorAction Stop
 	Write-Output "Building module..."
 	Invoke-Call { & "$MSBuild" "$MODULE_NAME.sln" /p:Configuration=Release /p:Platform=Win32 /m } -ErrorAction Stop
 	Pop-Location
 }
 
-if ($PROJECT_GENERATOR_VERSION -ge 3 && $env:DISABLE_64BIT -ne "true") {
+if (ValueIsFalsy $DISABLE_64BIT && $PROJECT_GENERATOR_VERSION -ge 3) {
 	Push-Location "$REPOSITORY_DIR/projects/$PROJECT_OS/$COMPILER_PLATFORM" -ErrorAction Stop
 	Write-Output "Building module..."
 	Invoke-Call { & "$MSBuild" "$MODULE_NAME.sln" /p:Configuration=Release /p:Platform=x64 /m } -ErrorAction Stop

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -14,12 +14,14 @@ Write-Output "Running premake5..."
 Invoke-Call { & "$PREMAKE5" "$COMPILER_PLATFORM" } -ErrorAction Stop
 Pop-Location
 
-Push-Location "$REPOSITORY_DIR/projects/$PROJECT_OS/$COMPILER_PLATFORM" -ErrorAction Stop
-Write-Output "Building module..."
-Invoke-Call { & "$MSBuild" "$MODULE_NAME.sln" /p:Configuration=Release /p:Platform=Win32 /m } -ErrorAction Stop
-Pop-Location
+if ($env:DISABLE_32BIT -ne "true") {
+	Push-Location "$REPOSITORY_DIR/projects/$PROJECT_OS/$COMPILER_PLATFORM" -ErrorAction Stop
+	Write-Output "Building module..."
+	Invoke-Call { & "$MSBuild" "$MODULE_NAME.sln" /p:Configuration=Release /p:Platform=Win32 /m } -ErrorAction Stop
+	Pop-Location
+}
 
-if ($PROJECT_GENERATOR_VERSION -ge 3) {
+if ($PROJECT_GENERATOR_VERSION -ge 3 && $env:DISABLE_64BIT -ne "true") {
 	Push-Location "$REPOSITORY_DIR/projects/$PROJECT_OS/$COMPILER_PLATFORM" -ErrorAction Stop
 	Write-Output "Building module..."
 	Invoke-Call { & "$MSBuild" "$MODULE_NAME.sln" /p:Configuration=Release /p:Platform=x64 /m } -ErrorAction Stop

--- a/build/build.sh
+++ b/build/build.sh
@@ -18,7 +18,7 @@ echo "Running premake5..."
 "$PREMAKE5" "$COMPILER_PLATFORM"
 popd
 
-if value_is_falsy "$DISABLE_32BIT" && { [ "$PROJECT_GENERATOR_VERSION" -le "2" ] || [ ! "$(uname -s)" = "Darwin" ]; }; then
+if value_is_falsy "$DISABLE_32BIT" && { [ "$PROJECT_GENERATOR_VERSION" -le "2" ] || [ "$(uname -s)" != "Darwin" ]; }; then
 	pushd "$REPOSITORY_DIR/projects/$PROJECT_OS/$COMPILER_PLATFORM"
 	echo "Building module with ${JOBS} job(s)..."
 	make -j "$JOBS" config=release_x86

--- a/build/build.sh
+++ b/build/build.sh
@@ -18,14 +18,30 @@ echo "Running premake5..."
 "$PREMAKE5" "$COMPILER_PLATFORM"
 popd
 
+BUILD_32BIT=false
 if [ "$PROJECT_GENERATOR_VERSION" -le "2" ] || [ ! "$(uname -s)" = "Darwin" ]; then
+	BUILD_32BIT=true
+fi
+if [ "${DISABLE_32BIT#false}" = "true" ]; then
+	BUILD_32BIT=false
+fi
+
+BUILD_64BIT=false
+if [ "$PROJECT_GENERATOR_VERSION" -ge "3" ]; then
+	BUILD_64BIT=true
+fi
+if [ "${DISABLE_64BIT#false}" = "true" ]; then
+	BUILD_64BIT=false
+fi
+
+if [ "${BUILD_32BIT}" = "true" ]; then
 	pushd "$REPOSITORY_DIR/projects/$PROJECT_OS/$COMPILER_PLATFORM"
 	echo "Building module with ${JOBS} job(s)..."
 	make -j "$JOBS" config=release_x86
 	popd
 fi
 
-if [ "$PROJECT_GENERATOR_VERSION" -ge "3" ]; then
+if [ "${BUILD_64BIT}" = "true" ]; then
 	pushd "$REPOSITORY_DIR/projects/$PROJECT_OS/$COMPILER_PLATFORM"
 	echo "Building module with ${JOBS} job(s)..."
 	make -j "$JOBS" config=release_x86_64

--- a/build/build.sh
+++ b/build/build.sh
@@ -18,30 +18,14 @@ echo "Running premake5..."
 "$PREMAKE5" "$COMPILER_PLATFORM"
 popd
 
-BUILD_32BIT=false
-if [ "$PROJECT_GENERATOR_VERSION" -le "2" ] || [ ! "$(uname -s)" = "Darwin" ]; then
-	BUILD_32BIT=true
-fi
-if [ "${DISABLE_32BIT#false}" = "true" ]; then
-	BUILD_32BIT=false
-fi
-
-BUILD_64BIT=false
-if [ "$PROJECT_GENERATOR_VERSION" -ge "3" ]; then
-	BUILD_64BIT=true
-fi
-if [ "${DISABLE_64BIT#false}" = "true" ]; then
-	BUILD_64BIT=false
-fi
-
-if [ "${BUILD_32BIT}" = "true" ]; then
+if value_is_falsy "$DISABLE_32BIT" && { [ "$PROJECT_GENERATOR_VERSION" -le "2" ] || [ ! "$(uname -s)" = "Darwin" ]; }; then
 	pushd "$REPOSITORY_DIR/projects/$PROJECT_OS/$COMPILER_PLATFORM"
 	echo "Building module with ${JOBS} job(s)..."
 	make -j "$JOBS" config=release_x86
 	popd
 fi
 
-if [ "${BUILD_64BIT}" = "true" ]; then
+if value_is_falsy "$DISABLE_64BIT" && [ "$PROJECT_GENERATOR_VERSION" -ge "3" ]; then
 	pushd "$REPOSITORY_DIR/projects/$PROJECT_OS/$COMPILER_PLATFORM"
 	echo "Building module with ${JOBS} job(s)..."
 	make -j "$JOBS" config=release_x86_64

--- a/build/functions.psm1
+++ b/build/functions.psm1
@@ -130,6 +130,14 @@ function GetMSBuildPath() {
 	return $MSBuild
 }
 
+function ValueIsTruthy($Value) {
+	return $Value -eq $true -or [bool]($Value -as [int])
+}
+
+function ValueIsFalsy($Value) {
+	return -not (ValueIsTruthy $Value)
+}
+
 Set-Variable MSBuild (GetMSBuildPath) -ErrorAction Stop -Confirm:$false
 
 Export-ModuleMember -Function ValidateVariableOrSetDefault, UpdateLocalGitRepository, CreateDirectoryForcefully, Invoke-Call, GetMSBuildPath -Variable MSBuild

--- a/build/functions.sh
+++ b/build/functions.sh
@@ -37,21 +37,25 @@ function update_local_git_repository {
 		echo "Fetching all branches from remote in \"${DIRECTORY}\"..."
 		git fetch --quiet --all --prune
 
-		local CURBRANCH=$(git symbolic-ref --quiet --short HEAD)
-		if [ ! "$BRANCH" = "$CURBRANCH" ]; then
+		local CURBRANCH
+		CURBRANCH=$(git symbolic-ref --quiet --short HEAD)
+		if [ "$BRANCH" != "$CURBRANCH" ]; then
 			echo "Checking out branch \"${BRANCH}\" in \"${DIRECTORY}\"..."
 			git checkout --quiet --force "$BRANCH"
 			local UPDATED=1
 		fi
 
-		local LOCAL=$(git rev-parse @)
-		local REMOTE=$(git rev-parse @{u})
-		local BASE=$(git merge-base @ @{u})
+		local LOCAL
+		LOCAL=$(git rev-parse @)
+		local REMOTE
+		REMOTE=$(git rev-parse @\{u\})
+		local BASE
+		BASE=$(git merge-base @ @\{u\})
 
 		if [ "$LOCAL" = "$BASE" ]; then
 			echo "Branch \"${BRANCH}\" in \"${DIRECTORY}\" needs updating..."
 			local UPDATED=1
-		elif [ ! "$LOCAL" = "$REMOTE" ]; then
+		elif [ "$LOCAL" != "$REMOTE" ]; then
 			echo "Hard resetting branch \"${BRANCH}\" in \"${DIRECTORY}\"..."
 			git reset --quiet --hard "origin/${BRANCH}"
 			git clean --quiet --force -dx

--- a/build/functions.sh
+++ b/build/functions.sh
@@ -80,3 +80,20 @@ function create_directory_forcefully {
 
 	mkdir -p "$DIRECTORY"
 }
+
+function value_is_truthy {
+	local VALUE="$1"
+	if { [[ "$VALUE" =~ ^[0-9]+$ ]] && [ "$VALUE" -ne 0 ]; } || [[ "$VALUE" =~ ^[tT][rR][uU][eE]$ ]]; then
+		return 0
+	else
+		return 1
+	fi
+}
+
+function value_is_falsy {
+	if value_is_truthy "$1"; then
+		return 1
+	else
+		return 0
+	fi
+}

--- a/build/setup.ps1
+++ b/build/setup.ps1
@@ -14,5 +14,7 @@ ValidateVariableOrSetDefault "PREMAKE5_URL" -Default "https://github.com/premake
 ValidateVariableOrSetDefault "PREMAKE5" -Default "$DEPENDENCIES/windows/premake-core/premake5.exe"
 ValidateVariableOrSetDefault "PROJECT_OS" -Default "windows"
 ValidateVariableOrSetDefault "PROJECT_GENERATOR_VERSION" -Default "1"
+ValidateVariableOrSetDefault "DISABLE_32BIT" -Default "0"
+ValidateVariableOrSetDefault "DISABLE_64BIT" -Default "0"
 
 CreateDirectoryForcefully $DEPENDENCIES

--- a/build/setup.sh
+++ b/build/setup.sh
@@ -37,5 +37,7 @@ case "$(uname -s)" in
 esac
 
 validate_variable_or_set_default "PREMAKE5" "$DEPENDENCIES/$PROJECT_OS/premake-core/premake5"
+validate_variable_or_set_default "DISABLE_32BIT" "0"
+validate_variable_or_set_default "DISABLE_64BIT" "0"
 
 create_directory_forcefully "$DEPENDENCIES"

--- a/build/setup.sh
+++ b/build/setup.sh
@@ -18,12 +18,10 @@ validate_variable_or_set_default "PROJECT_GENERATOR_VERSION" "1"
 
 case "$(uname -s)" in
     Linux*)
-        TARGET="linux"
         validate_variable_or_set_default "PREMAKE5_URL" "https://github.com/premake/premake-core/releases/download/v5.0.0-alpha15/premake-5.0.0-alpha15-linux.tar.gz"
         validate_variable_or_set_default "PROJECT_OS" "linux"
         ;;
     Darwin*)
-        TARGET="osx"
         validate_variable_or_set_default "PREMAKE5_URL" "https://github.com/premake/premake-core/releases/download/v5.0.0-alpha15/premake-5.0.0-alpha15-macosx.tar.gz"
         validate_variable_or_set_default "PROJECT_OS" "macosx"
         validate_variable_or_set_default "MACOSX_SDK_URL" "https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.7.sdk.tar.xz"


### PR DESCRIPTION
For example, `enginespew` needs different branches to build 32 and 64 bit, so the builds need to be separated entirely.

This should not change the default behaviour at all.